### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,20 +41,6 @@ Two primary functions are provided in this package currently:
   *  :param *return_index*: Boolean, to determine whether the solution contains the indices or column names of selected features, the default is False
   *  :param *return_with_fixed*: Boolean, to determine whether the solution contains the fixed selected features, the default is True
   *  :return: Pandas series, the solutions of selected features
-  
-
-
-* mrmr_ensemble_survival: It provides the ensemble (multiple) solutions of feature selection given the input of feature dataset and target column, it supports the feature selection with preselection as well. 
-  *  :param *features*: Pandas dataframe, the input dataset
-  *  :param *targets*: Pandas dataframe, the target features, it must have two columns (event and time of survival data)
-  *  :param *fixed_features*: List, the list of fixed features (column names), the default is empty list
-  *  :param *category_features*: List, the list of features whose types are categorical (column names), the default is empty list
-  *  :param *solution_length*: Integer, the number of features contained in one solution
-  *  :param *solution_count*: Integer, the number of solutions to be returned, the default is 1
-  *  :param *estimator*: String, the way of computing continuous estimators, the default is Pearson
-  *  :param *return_index*: Boolean, to determine whether the solution contains the indices or column names of selected features, the default is False
-  *  :param *return_with_fixed*: Boolean, to determine whether the solution contains the fixed selected features, the default is True
-  *  :return: Pandas series, the solutions of selected features
 
 Example code:
 
@@ -63,7 +49,7 @@ import pandas as pd
 `
 <br>
 `
-from Pymrmre import mrmr
+from pymrmre import mrmr
 `
 
 Load the input data and target variable, suppose for input X we have ten features (*f1*, *f2*, ..., *f10*):


### PR DESCRIPTION
Fix #6  typo in PymRMRe import statement (only all lowercase works cross-platform)
* Also removed example code for `mrmr_ensemble_survival` for the README, since as far as I can tell, the only difference was that this function expected two columns (event, survival_time) and added no additional features vs `mrmr_enesemble`.